### PR TITLE
Update rsync to release 3.2.3-4+deb11u3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ env:
   RSYNC_VERSION_MINOR: '3.2'
   RSYNC_VERSION_PATCH: '3'
   RSYNC_VERSION_PACKAGE: '4'
-  RSYNC_VERSION_DEBIAN: 'deb11u1'
+  RSYNC_VERSION_DEBIAN: 'deb11u3'
   DOCKERHUB_REPO: ${{ vars.DOCKERHUB_USERNAME }}/debian-rsync
   GHCR_REPO: ghcr.io/${{ github.repository }}
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Build Docker image
-        uses: hbielenia/docker-build-action@7211d36e8ed0a62e6ef2f8610b734896e93d8190 # 0.2.0
+        uses: hbielenia/docker-build-action@2dd2f6d3d269aa3e95e4ac232d2714c1c67453a0 # 0.2.4
         with:
           dockerfile: ./dockerfiles/${{ inputs.debian_version }}.Dockerfile
           tags: ${{ env.DOCKERHUB_REPO }}:latest
@@ -54,7 +54,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Docker image
-        uses: hbielenia/docker-build-action@7211d36e8ed0a62e6ef2f8610b734896e93d8190 # 0.2.0
+        uses: hbielenia/docker-build-action@2dd2f6d3d269aa3e95e4ac232d2714c1c67453a0 # 0.2.4
         with:
           dockerfile: ./dockerfiles/${{ inputs.debian_version }}.Dockerfile
           from_cache: '1'
@@ -71,7 +71,7 @@ jobs:
             ${{ env.GHCR_REPO }}:${{ env.RSYNC_VERSION_MINOR }}.${{ env.RSYNC_VERSION_PATCH }}-${{ env.RSYNC_VERSION_PACKAGE }}-${{ env.RSYNC_VERSION_DEBIAN }}-${{ inputs.debian_version }},
       - name: Push generic tags
         if: inputs.latest
-        uses: hbielenia/docker-build-action@7211d36e8ed0a62e6ef2f8610b734896e93d8190 # 0.2.0
+        uses: hbielenia/docker-build-action@2dd2f6d3d269aa3e95e4ac232d2714c1c67453a0 # 0.2.4
         with:
           dockerfile: ./dockerfiles/${{ inputs.debian_version }}.Dockerfile
           from_cache: '1'

--- a/dockerfiles/bullseye-slim.Dockerfile
+++ b/dockerfiles/bullseye-slim.Dockerfile
@@ -11,7 +11,7 @@
 FROM debian:bullseye-slim@sha256:60a596681410bd31a48e5975806a24cd78328f3fd6b9ee5bc64dca6d46a51f29
 RUN adduser --disabled-password --no-create-home --uid 1000 rsync
 RUN apt-get update \
-	&& apt-get install -y rsync=3.2.3-4+deb11u1 \
+	&& apt-get install -y rsync=3.2.3-4+deb11u3 \
 	&& rm -rf /var/lib/apt/lists/*
 USER 1000:1000
 ENTRYPOINT [ "/usr/bin/rsync" ]

--- a/dockerfiles/bullseye.Dockerfile
+++ b/dockerfiles/bullseye.Dockerfile
@@ -11,7 +11,7 @@
 FROM debian:bullseye@sha256:01559430c84e6bc864bed554345d1bfbfa94ac108ab68f39915cae34604b15c3
 RUN adduser --disabled-password --no-create-home --uid 1000 rsync
 RUN apt-get update \
-	&& apt-get install -y rsync=3.2.3-4+deb11u1 \
+	&& apt-get install -y rsync=3.2.3-4+deb11u3 \
 	&& rm -rf /var/lib/apt/lists/*
 USER 1000:1000
 ENTRYPOINT [ "/usr/bin/rsync" ]


### PR DESCRIPTION
Updates rsync to release 3.2.3-4+deb11u3, released on 2025-01-17.