### PR TITLE
Fix the image test step in GH Actions workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
           dockerfile: ./dockerfiles/${{ inputs.debian_version }}.Dockerfile
           tags: ${{ env.DOCKERHUB_REPO }}:latest
       - name: Test the built image
-        run: docker run --rm ${{ env.DOCKERHUB_REPO }}:latest mypy --version
+        run: docker run --rm ${{ env.DOCKERHUB_REPO }}:latest --version
   upload:
     if: inputs.push
     needs: build


### PR DESCRIPTION
Removes the accidentally copied `mypy` from the test step in GitHub Actions workflow. This had no actual impact because rsync transparently consumed the unnecessary parameter, but still shouldn't be present to avoid confusion.